### PR TITLE
Fix example of building the breadcrumbs manually [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ end
 If you supply a block to the `breadcrumbs` method, it will yield an array with the breadcrumb links so you can build the breadcrumbs HTML manually:
 
 ```erb
-<% breadcrumbs do |links| %>
+<% breadcrumbs.tap do |links| %>
   <% if links.any? %>
     You are here:
     <% links.each do |link| %>


### PR DESCRIPTION
It seems to need `tap` now.
https://github.com/WilHall/gretel/blob/develop/lib/gretel/deprecated/yield_links.rb