### PR TITLE
Schema.org formatted structured data

### DIFF
--- a/lib/gretel/renderer.rb
+++ b/lib/gretel/renderer.rb
@@ -194,8 +194,14 @@ module Gretel
         end
 
         html = html_fragments.join(" ").html_safe
-        content_tag(options[:container_tag], html, id: options[:id], class: options[:class], itemscope: "", itemtype: "http://schema.org/BreadcrumbList")
-      end
+        
+        if options[:semantic]
+          content_tag(options[:container_tag], html, id: options[:id], class: options[:class], itemscope: "", itemtype: "https://schema.org/BreadcrumbList")
+        else
+          content_tag(options[:container_tag], html, id: options[:id], class: options[:class])
+        end
+
+     end
 
       alias :to_s :render
 

--- a/lib/gretel/renderer.rb
+++ b/lib/gretel/renderer.rb
@@ -171,13 +171,14 @@ module Gretel
         return "" if links.empty?
 
         # Loop through all but the last (current) link and build HTML of the fragments
-        fragments = links[0..-2].map do |link|
-          render_fragment(options[:fragment_tag], link.text, link.url, options[:semantic], fragment_class: options[:fragment_class])
+        fragments = links[0..-2].map.with_index do |link, index|
+          render_fragment(options[:fragment_tag], link.text, link.url, options[:semantic], index + 1, fragment_class: options[:fragment_class])
         end
 
         # The current link is handled a little differently, and is only linked if specified in the options
         current_link = links.last
-        fragments << render_fragment(options[:fragment_tag], current_link.text, (options[:link_current] ? current_link.url : nil), options[:semantic], fragment_class: options[:fragment_class], class: options[:current_class], current_link: current_link.url)
+        position = links.size
+        fragments << render_fragment(options[:fragment_tag], current_link.text, (options[:link_current] ? current_link.url : nil), options[:semantic], position, fragment_class: options[:fragment_class], class: options[:current_class], current_link: current_link.url)
 
         # Build the final HTML
         html_fragments = []
@@ -193,41 +194,36 @@ module Gretel
         end
 
         html = html_fragments.join(" ").html_safe
-        content_tag(options[:container_tag], html, id: options[:id], class: options[:class])
+        content_tag(options[:container_tag], html, id: options[:id], class: options[:class], itemscope: "", itemtype: "http://schema.org/BreadcrumbList")
       end
 
       alias :to_s :render
 
       # Renders HTML for a breadcrumb fragment, i.e. a breadcrumb link.
-      def render_fragment(fragment_tag, text, url, semantic, options = {})
+      def render_fragment(fragment_tag, text, url, semantic, position, options = {})
         if semantic
-          render_semantic_fragment(fragment_tag, text, url, options)
+          render_semantic_fragment(fragment_tag, text, url, position, options)
         else
           render_nonsemantic_fragment(fragment_tag, text, url, options)
         end
       end
 
       # Renders semantic fragment HTML.
-      def render_semantic_fragment(fragment_tag, text, url, options = {})
+      def render_semantic_fragment(fragment_tag, text, url, position, options = {})
         fragment_class = [options[:fragment_class], options[:class]].join(' ').strip
         fragment_class = nil if fragment_class.blank?
+        fragment_tag = fragment_tag || 'span'
+        text = content_tag(:span, text, itemprop: "name")
 
-        if fragment_tag
-          text = content_tag(:span, text, itemprop: "title")
-
-          if url.present?
-            text = breadcrumb_link_to(text, url, itemprop: "url")
-          elsif options[:current_link].present?
-            current_url = "#{root_url}#{options[:current_link].gsub(/^\//, '')}"
-            text = text + tag(:meta, itemprop: "url", content: current_url)
-          end
-
-          content_tag(fragment_tag, text, class: fragment_class, itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")
-        elsif url.present?
-          content_tag(:span, breadcrumb_link_to(content_tag(:span, text, itemprop: "title"), url, class: fragment_class, itemprop: "url"), itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")
-        else
-          content_tag(:span, content_tag(:span, text, class: fragment_class, itemprop: "title"), itemscope: "", itemtype: "http://data-vocabulary.org/Breadcrumb")
+        if url.present?
+          text = breadcrumb_link_to(text, url, itemprop: "item")
+        elsif options[:current_link].present?
+          current_url = "#{root_url}#{options[:current_link].gsub(/^\//, '')}"
+          text = text + tag(:meta, itemprop: "item", content: current_url)
         end
+
+        text = text + tag(:meta, itemprop:"position", content: "#{position}")
+        content_tag(fragment_tag.to_sym, text, class: fragment_class, itemprop: "itemListElement", itemscope: "", itemtype: "https://schema.org/ListItem")
       end
 
       # Renders regular, non-semantic fragment HTML.

--- a/test/helper_methods_test.rb
+++ b/test/helper_methods_test.rb
@@ -63,7 +63,7 @@ class HelperMethodsTest < ActionView::TestCase
 
   test "semantic breadcrumb" do
     breadcrumb :with_root
-    assert_dom_equal %Q{<div class="breadcrumbs"><span itemscope="#{itemscope_value}" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/" itemprop="url"><span itemprop="title">Home</span></a></span> &rsaquo; <span itemscope="#{itemscope_value}" itemtype="http://data-vocabulary.org/Breadcrumb"><span class="current" itemprop="title">About</span></span></div>},
+    assert_dom_equal %{<div class="breadcrumbs" itemscope="#{itemscope_value}" itemtype="https://schema.org/BreadcrumbList"><span itemprop="itemListElement" itemscope="#{itemscope_value}" itemtype="https://schema.org/ListItem"><a itemprop="item" href="/"><span itemprop="name">Home</span></a><meta itemprop="position" content="1" /></span> &rsaquo; <span class="current" itemprop="itemListElement" itemscope="#{itemscope_value}" itemtype="https://schema.org/ListItem"><span itemprop="name">About</span><meta itemprop="item" content="http://test.host/about" /><meta itemprop="position" content="2" /></span></div>},
                  breadcrumbs(semantic: true).to_s
   end
 
@@ -373,7 +373,7 @@ class HelperMethodsTest < ActionView::TestCase
   test "foundation5 style" do
     breadcrumb :basic
     assert_dom_equal %{<ul class="breadcrumbs"><li><a href="/">Home</a></li><li class="current">About</li></ul>},
-	         breadcrumbs(style: :foundation5).to_s
+                 breadcrumbs(style: :foundation5).to_s
   end
 
   test "custom container and fragment tags" do
@@ -384,7 +384,7 @@ class HelperMethodsTest < ActionView::TestCase
 
   test "custom semantic container and fragment tags" do
     breadcrumb :basic
-    assert_dom_equal %Q{<c class="breadcrumbs"><f itemscope="#{itemscope_value}" itemtype="http://data-vocabulary.org/Breadcrumb"><a itemprop="url" href="/"><span itemprop="title">Home</span></a></f> &rsaquo; <f class="current" itemscope="#{itemscope_value}" itemtype="http://data-vocabulary.org/Breadcrumb"><span itemprop="title">About</span><meta itemprop="url" content="http://test.host/about" /></f></c>},
+    assert_dom_equal %{<c class="breadcrumbs" itemscope="#{itemscope_value}" itemtype="https://schema.org/BreadcrumbList"><f itemprop="itemListElement" itemscope="#{itemscope_value}" itemtype="https://schema.org/ListItem"><a itemprop="item" href="/"><span itemprop="name">Home</span></a><meta itemprop="position" content="1" /></f> &rsaquo; <f class="current" itemprop="itemListElement" itemscope="#{itemscope_value}" itemtype="https://schema.org/ListItem"><span itemprop="name">About</span><meta itemprop="item" content="http://test.host/about" /><meta itemprop="position" content="2" /></f></c>},
                  breadcrumbs(container_tag: :c, fragment_tag: :f, semantic: true).to_s
   end
 


### PR DESCRIPTION
I have cherry-picked @StarWar's commits from lassebunk#105, less the version bump and some other formatting changes, into @WillHall/gretel. This uses schema.org semantic markup for structured data, which Google now prefers. See issue #16.