### PR TITLE
Change meta elements for links to link elements

### DIFF
--- a/lib/gretel/renderer.rb
+++ b/lib/gretel/renderer.rb
@@ -320,11 +320,10 @@ module Gretel
           text = breadcrumb_link_to(text, url, itemprop: "item", "aria-current": aria_current, class: options[:link_class])
           aria_current = nil
         elsif options[:current_link].present?
-          current_url = "#{root_url}#{options[:current_link].gsub(/^\//, '')}"
-          text = text + tag(:meta, itemprop: "item", content: current_url)
+          text = text + tag(:link, itemprop: "item", href: options[:current_link])
         end
 
-        text = text + tag(:meta, itemprop:"position", content: "#{position}")
+        text = text + tag(:meta, itemprop: "position", content: "#{position}")
         content_tag(fragment_tag.to_sym, text, class: fragment_class, itemprop: "itemListElement", itemscope: "", itemtype: "https://schema.org/ListItem", "aria-current": aria_current)
       end
 

--- a/spec/lib/gretel/view_helpers_spec.rb
+++ b/spec/lib/gretel/view_helpers_spec.rb
@@ -45,7 +45,7 @@ describe Gretel::ViewHelpers, type: :helper do
 
     it "semantic breadcrumb" do
       breadcrumb :with_root
-      assert_dom_equal(%{<div class="breadcrumbs" itemscope="itemscope" itemtype="https://schema.org/BreadcrumbList"><span itemprop="itemListElement" itemscope="itemscope" itemtype="https://schema.org/ListItem"><a itemprop="item" href="/"><span itemprop="name">Home</span></a><meta itemprop="position" content="1" /></span> &rsaquo; <span class="current" itemprop="itemListElement" itemscope="itemscope" itemtype="https://schema.org/ListItem"><span itemprop="name">About</span><meta itemprop="item" content="http://test.host/about" /><meta itemprop="position" content="2" /></span></div>}, breadcrumbs(semantic: true).to_s)
+      assert_dom_equal(%{<div class="breadcrumbs" itemscope="itemscope" itemtype="https://schema.org/BreadcrumbList"><span itemprop="itemListElement" itemscope="itemscope" itemtype="https://schema.org/ListItem"><a itemprop="item" href="/"><span itemprop="name">Home</span></a><meta itemprop="position" content="1" /></span> &rsaquo; <span class="current" itemprop="itemListElement" itemscope="itemscope" itemtype="https://schema.org/ListItem"><span itemprop="name">About</span><link itemprop="item" href="/about" /><meta itemprop="position" content="2" /></span></div>}, breadcrumbs(semantic: true).to_s)
     end
 
     it "semantic breadcrumb with current link" do
@@ -365,7 +365,7 @@ describe Gretel::ViewHelpers, type: :helper do
 
     it "custom semantic container and fragment tags" do
       breadcrumb :basic
-      assert_dom_equal(%{<c class="breadcrumbs" itemscope="itemscope" itemtype="https://schema.org/BreadcrumbList"><f itemprop="itemListElement" itemscope="itemscope" itemtype="https://schema.org/ListItem"><a itemprop="item" href="/"><span itemprop="name">Home</span></a><meta itemprop="position" content="1" /></f> &rsaquo; <f class="current" itemprop="itemListElement" itemscope="itemscope" itemtype="https://schema.org/ListItem"><span itemprop="name">About</span><meta itemprop="item" content="http://test.host/about" /><meta itemprop="position" content="2" /></f></c>}, breadcrumbs(container_tag: :c, fragment_tag: :f, semantic: true).to_s)
+      assert_dom_equal(%{<c class="breadcrumbs" itemscope="itemscope" itemtype="https://schema.org/BreadcrumbList"><f itemprop="itemListElement" itemscope="itemscope" itemtype="https://schema.org/ListItem"><a itemprop="item" href="/"><span itemprop="name">Home</span></a><meta itemprop="position" content="1" /></f> &rsaquo; <f class="current" itemprop="itemListElement" itemscope="itemscope" itemtype="https://schema.org/ListItem"><span itemprop="name">About</span><link itemprop="item" href="/about" /><meta itemprop="position" content="2" /></f></c>}, breadcrumbs(container_tag: :c, fragment_tag: :f, semantic: true).to_s)
     end
 
     it "unknown style" do


### PR DESCRIPTION
In semantic breadcrumbs with Microdata, It is better to use link elements to represent URLs other than the A element.
Relative URL can be used with link elements instead of meta elements.

https://html.spec.whatwg.org/multipage/microdata.html#values
> **If the element is an a, area, or link element**
> The value is the resulting URL string that results from parsing the value of the element's href attribute relative to the node document of the element at the time the attribute is set, or the empty string if there is no such attribute or if parsing it results in an error.

However, according to Google's guidelines, the last item in the breadcrumb trail is optional, so you may as well eliminate the element.

https://developers.google.com/search/docs/advanced/structured-data/breadcrumb#list-item
> If the breadcrumb is the last item in the breadcrumb trail, `item` is not required. If `item` isn't included for the last item, Google uses the URL of the containing page.