### PR TITLE
Fix json_ld string format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 * Detach fork
 
+## Version 5.0.2
+* Fix json-ld string format (via #8, thanks @mario-amazing)
+
 ## Version 5.0.1
 * Support Rails 7.2 (via #45, thanks @alec-c4)
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ add them back is to use JSON-LD structured data:
 
 ```erb
 <script type="application/ld+json">
-  <%= breadcrumbs.structured_data(url_base: "https://example.com") %>
+  <%= raw breadcrumbs.structured_data(url_base: "https://example.com").to_json %>
 </script>
 ```
 
@@ -241,7 +241,7 @@ Or, you can infer `url_base` from `request`:
 
 ```erb
 <script type="application/ld+json">
-  <%= breadcrumbs.structured_data(url_base: "#{request.protocol}#{request.host_with_port}") %>
+  <%= raw breadcrumbs.structured_data(url_base: "#{request.protocol}#{request.host_with_port}").to_json %>
 </script>
 ```
 

--- a/lib/gretel/renderer.rb
+++ b/lib/gretel/renderer.rb
@@ -170,17 +170,17 @@ module Gretel
 
         items = @links.each_with_index.map do |link, i|
           {
-            "@type": "ListItem",
-            "position": i + 1,
-            "name": link.text,
-            "item": "#{url_base}#{link.url}"
+            "@type" => "ListItem",
+            "position" => i + 1,
+            "name" => link.text,
+            "item" => "#{url_base}#{link.url}"
           }
         end
 
         {
-          "@context": "https://schema.org",
-          "@type": "BreadcrumbList",
-          "itemListElement": items
+          "@context" => "https://schema.org",
+          "@type" => "BreadcrumbList",
+          "itemListElement" => items
         }
       end
 

--- a/lib/gretel/version.rb
+++ b/lib/gretel/version.rb
@@ -1,3 +1,3 @@
 module Gretel
-  VERSION = "5.0.1"
+  VERSION = "5.0.2"
 end


### PR DESCRIPTION
Issue: keys auto converts to symbols in ruby '3.3.3' and rails 7.2.0
<img width="777" alt="image" src="https://github.com/user-attachments/assets/8800837f-fd65-4625-87b0-f2d3561e90e0">

Fix:
Ensure that all keys remain strings when generating the structured data by explicitly using the hash rocket => for all key-value pairs.